### PR TITLE
remove extra trailing NUL on kSymbols

### DIFF
--- a/lisp.c
+++ b/lisp.c
@@ -72,7 +72,7 @@ _Alignas(char) const char kSymbols[] = "NIL\0"
                                        "CAR\0"
                                        "CDR\0"
                                        "CONS\0"
-                                       "LAMBDA\0";
+                                       "LAMBDA";
 
 #ifdef __REAL_MODE__
 static struct Lisp *const q;

--- a/sectorlisp.S
+++ b/sectorlisp.S
@@ -51,7 +51,7 @@ main:	mov	$q.syntax,%bx
 	movb	$46,46(%bx)
 	mov	$STR,%di
 	mov	$kSymbols,%si
-	mov	$57,%cx
+	mov	$56,%cx
 	rep movsb
 0:	call	GetChar
 	mov	%ax,q.look

--- a/sectorlisp.S
+++ b/sectorlisp.S
@@ -441,4 +441,3 @@ kSymbols:
 	.string	"CDR"
 	.string	"CONS"
 	.string	"LAMBDA"
-	.string	""


### PR DESCRIPTION
It wastes a byte this way -- see https://godbolt.org/z/nEj9hc
See diff of hexdump of sectorlisp.bin before/after:

```
*** before.txt  2021-02-27 13:17:47.842081600 -0800
--- after.txt   2021-02-27 13:16:40.789140700 -0800
***************
*** 31,33 ****
  000001e0: 4551 0043 4f4e 4400 4341 5200 4344 5200  EQ.COND.CAR.CDR.
! 000001f0: 434f 4e53 004c 414d 4244 4100 0090 55aa  CONS.LAMBDA...U.
  00000200: f7c7 0100 7509 d1ef 8db5 8641 e9a3 ff53  ....u......A...S
--- 31,33 ----
  000001e0: 4551 0043 4f4e 4400 4341 5200 4344 5200  EQ.COND.CAR.CDR.
! 000001f0: 434f 4e53 004c 414d 4244 4100 6690 55aa  CONS.LAMBDA.f.U.
  00000200: f7c7 0100 7509 d1ef 8db5 8641 e9a3 ff53  ....u......A...S
```

Second zero byte after LAMBDA is now uninitialized.