### PR TITLE
Support for higher order functions

### DIFF
--- a/lisp.c
+++ b/lisp.c
@@ -342,6 +342,8 @@ int Evaluate(int e, int a) {
       return Car(Cdr(e));
     if (ax == ATOM_COND)
       return Evcon(Cdr(e), a);
+    if (ax == ATOM_LAMBDA)
+      return e;
   }
   return Apply(ax, Evlis(Cdr(e), a), a);
 }


### PR DESCRIPTION
```
$ echo "((LAMBDA (f) (f (QUOTE a))) (LAMBDA (z) (CONS z z)))" | ./lisp 
THE LISP CHALLENGE V1
VISIT GITHUB.COM/JART
(a∙a)
```

Ah, now I see that in your meta-evaluator code example you add QUOTE around LAMBDA... I see.... Minimalism bordering on the ugly... again :P

I'm goinf to leave this here as a closed PR as a warning to others :P 