### PR TITLE
Reduce one byte by using the string "T" contained within the code

### DIFF
--- a/sectorlisp.S
+++ b/sectorlisp.S
@@ -25,7 +25,7 @@
 	.code16
 	.globl	_start
 _start:	.asciz	"NIL"				# dec %si ; dec %cx ; dec %sp
-kT:	.asciz	"T"				# add %dl,(%si) boot A:\ DL=0
+	.asciz	"T"				# add %dl,(%si) boot A:\ DL=0
 start:	ljmp	$0x7c00>>4,$begin		# cs = 0x7c00 is boot address
 	.asciz	""				# interned strings
 kQuote:	.asciz	"QUOTE"				# builtin for eval
@@ -52,7 +52,8 @@ begin:	mov	$0x8000,%sp			# uses higher address as stack
 	mov	$2,%bx
 main:	mov	%sp,%cx
 	call	GetToken
-	call	GetObject
+kT:	call	GetObject			# $kT + 1 == $0x5400 == "T"
+						# Depends on the jump width
 	call	Eval
 	xchg	%ax,%si
 	call	PrintObject
@@ -221,7 +222,7 @@ Pairlis:test	%di,%di				# Pairlis(x:di,y:si,a:dx):dx
 	je	Cons
 .isEq:	xor	%ax,%di
 	jne	.retF
-.retT:	mov	$kT,%al
+.retT:	mov	$kT+1,%al			# $kT is $0xe85400. $kT+1 is "T"
 	ret
 .ifAtom:test	%di,%di				# test if atom
 	jns	.retT
@@ -292,3 +293,4 @@ Eval:	test	%ax,%ax				# Eval(e:ax,a:dx):ax
 	.type	kCdr,@object
 	.type	kCons,@object
 	.type	kEq,@object
+	.type	kT,@object

--- a/sectorlisp.S
+++ b/sectorlisp.S
@@ -25,7 +25,7 @@
 	.code16
 	.globl	_start
 _start:	.asciz	"NIL"				# dec %si ; dec %cx ; dec %sp
-	.asciz	"T"				# add %dl,(%si) boot A:\ DL=0
+	.byte	0x01				# add %al,(%bx,%di)BX,DI,AL=0
 start:	ljmp	$0x7c00>>4,$begin		# cs = 0x7c00 is boot address
 	.asciz	""				# interned strings
 kQuote:	.asciz	"QUOTE"				# builtin for eval


### PR DESCRIPTION
(edit: There currently are some issues with this PR - please see my 5th comment in this thread.)

It just so happens that the string "T" already lies within the code!

This pull request shaves one byte off the program by using the string "T" which appears in the later part of the code, replacing the `T` at the header.

The bytes `0x5400` which reads as "T" are located at the address 0x3e in the original binary:
```
00000000: 4e49 4c00 5400 ea2c 00c0 0700 5155 4f54  NIL.T..,....QUOT
00000010: 4500 434f 4e44 0043 4152 0043 4452 0043  E.COND.CAR.CDR.C
00000020: 4f4e 5300 4551 0041 544f 4d00 bc00 800e  ONS.EQ.ATOM.....
00000030: 1f0e 070e 17bb 0200 89e1 e811 00e8 5400  ..............T.
```
This pull request uses these bytes 0x5400 for the representation of the atom `T`, and removes the unused fifth byte `T`, shaving off one byte from the entire program. Note that Due to the `0x00` after `NIL` (which is read as `add`), the `0x00` after `T` could not be removed.

Removing the `T` at the fifth byte changes the first 5 instructions as follows:
```
07c00        4e          dec     %si
007c01       49          dec     %cx
007c02       4c          dec     %sp
007c03       0000        add     %al,(%bx,%si)
007c05       ea2b00c007  ljmp    $0x7c0,$0x2b
```
At the time of execution, `AL == BX == 0`, and `SI == 0xffff` because of the first instruction. Since the value at `(%bx,%si)` is initially zero, it writes `0` to `AL` which effectively does nothing.

## Testing
I ran the program up to the first `ljmp` instruction in the header on Blinkenlights, and it seems that all of the registers and the memory except the instruction pointer (which is 1 less) seems to be having the same values.

I also ran the metacircular evaluator in [lisp.lisp](./lisp.lisp) and confirmed that it shows the correct result `A`.

## Robustness
This method depends on the jump width of the `call GetObject` instruction at the third step of `main`, i.e., the width between `call GetObject` and `GetObject`. For example, adding an `nop` after these jumps increments the bytes to `0x5500` as follows:

Code with `nop`:
```
007c3c       e85500      call    _edata+0x6c94
007c3f       e84001      call    _edata+0x6d82
007c42       90          nop
```
The original code without `nop`:
```
007c3c       e85400      call    _edata+0x6c93
007c3f       e83f01      call    _edata+0x6d81
```

Therefore, the idea of using `T` can be robustly used as long as the width between `main` and `GetObject` does not change, i.e. the 0x54 == 84 bytes in between are unchanged.