### PR TITLE
Fix bug for `EQ` where a null string is printed

### DIFF
--- a/sectorlisp.S
+++ b/sectorlisp.S
@@ -219,7 +219,7 @@ Pairlis:test	%di,%di				# Pairlis(x:di,y:si,a:dx):dx
 .ifCons:mov	(%bx,%si),%si			# si = Cdr(x)
 	lodsw					# si = Cadr(x)
 	je	Cons
-.isEq:	xor	%ax,%di
+.isEq:	xor	%di,%ax
 	jne	.retF
 .retT:	mov	$kT,%al
 	ret


### PR DESCRIPTION
Fixes #16.

I tested the resulting binary by running `make test1` in `./test`, and by running the metacircular evaluator in [lisp.lisp](./lisp.lisp) in Blinkenlights.