### PR TITLE
Specify std version as gnu89

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = -w -O
+CFLAGS = -std=gnu89 -w -O
 
 CLEANFILES =				\
 	lisp				\


### PR DESCRIPTION
This lets clang compile lisp.c, which, unlike gcc, errors by default (instead of warning) on depreciated C89 constructs like implicit int unless c89/gnu89 is specifically selected. Tested with clang 18 and 19.

Alternatively, any of the suggested fixes in #31 for gcc 14 would allow clang to compile this. However, this may still help clarify the intent of the code.