### PR TITLE
Adds K and R function prototypes

### DIFF
--- a/lisp.c
+++ b/lisp.c
@@ -21,6 +21,7 @@
 #ifndef __COSMOPOLITAN__
 #include <ctype.h>
 #include <stdio.h>
+#include <wchar.h>
 #include <stdlib.h>
 #include <string.h>
 #include <locale.h>

--- a/lisp.c
+++ b/lisp.c
@@ -50,6 +50,17 @@ int cx; /* stores negative memory use */
 int dx; /* stores lookahead character */
 int RAM[0100000]; /* your own ibm7090 */
 
+int AddList();
+int GetList();
+int GetObject();
+void PrintList();
+void PrintObject();
+void PrintChar();
+int Car();
+int Cdr();
+int Cons();
+int Eval();
+
 Intern() {
   int i, j, x;
   for (i = 0; (x = M[i++]);) {


### PR DESCRIPTION
This adds K and R style function prototypes to sectorlisp. This is an alternative to #31  and eliminates the need for 
`-Wno-implicit-function-declaration`