### PR TITLE
Treat invalid input as ']' to save a cmp instruction.

### DIFF
--- a/brainfuck.S
+++ b/brainfuck.S
@@ -29,13 +29,13 @@ _start:	mov	$0x7e00,%di
 Load:	xor	%ax,%ax
 	int	$0x16
 	stosb
+	cmp	$'$',%al
+	je	LdDone
 	cmp	$'[',%al
 	je	Lsb
-	cmp	$']',%al
-	je	Rsb
-	cmp	$'$',%al
-	jne	Load
-	pop	%si
+	# Treat invalid char as ']' to save an instruction
+	jmp	Rsb
+LdDone:	pop	%si
 Brain:	lodsb
         cbw
 	mov	$0x0e,%bh


### PR DESCRIPTION
If we don't care about invalid input characters, I think we can save an instruction. I believe the current behavior is to skip them.

Disclaimer: I haven't tested this; I can't figure out how to provide input to the program under blinkenlights (WSL2 in Windows Terminal) or qemu-system-x86_64 other than manually keying it in, which is tedious and error-prone.